### PR TITLE
Grant access to Gamescope socket for Steam Deck OLED

### DIFF
--- a/flatpak/io.github.starfox64recomp.starfox64recomp.json
+++ b/flatpak/io.github.starfox64recomp.starfox64recomp.json
@@ -13,7 +13,8 @@
     "--filesystem=host",
     "--filesystem=/media",
     "--filesystem=/run/media",
-    "--filesystem=/mnt"
+    "--filesystem=/mnt",
+    "--filesystem=xdg-run/gamescope-0:ro"
   ],
   "modules": [
     {


### PR DESCRIPTION
* See https://github.com/flathub/org.DolphinEmu.dolphin-emu/pull/178#issuecomment-1905194043 for more information
* Bug only occurs on the Steam Deck OLED.

To replicate the error, on a Steam Deck OLED, install the Flatpak, launch the recomp in Game Mode, see error. Gamescope Flatpak is primarily used for HDR in other Flatpaks (Dolphin, PrimeHack, Heroic, etc.).

![image](https://github.com/user-attachments/assets/745b9487-b8ed-4d3f-bb55-6e02c152ba92)